### PR TITLE
Expand widths of recently modified event columns

### DIFF
--- a/database/migrations/2018_01_05_143000_fix_event_column_widths.php
+++ b/database/migrations/2018_01_05_143000_fix_event_column_widths.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class FixEventColumnWidths extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('ScheduledAction', function (Blueprint $table) {
+            $table->text('Start',16)->nullable()->change();
+            $table->text('End',16)->nullable()->change();
+            $table->text('CustomStart',256)->nullable()->change();
+            $table->text('CommitteeLink',256)->nullable()->change();
+        });
+        Schema::table('Action', function (Blueprint $table) {
+            $table->text('CommitteeLink',256)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('ScheduledAction', function (Blueprint $table) {
+            $table->text('Start')->nullable()->change();
+            $table->text('End')->nullable()->change();
+            $table->text('CustomStart')->nullable()->change();
+            $table->text('CommitteeLink')->nullable()->change();
+        });
+        Schema::table('Action', function (Blueprint $table) {
+            $table->text('CommitteeLink')->nullable()->change();
+        });
+    }
+}


### PR DESCRIPTION
Previous migrations truncated these columns to a width of one. No data appears to have been lost in the test DB, so hopefully we can just tweak the schema and move on.