### PR TITLE
Search by author/coauthor

### DIFF
--- a/app/Bill.php
+++ b/app/Bill.php
@@ -72,6 +72,8 @@ class Bill extends Model
      * hide some relations from serialization
      */
     protected $hidden = [
+        "authors",
+        "coauthors",
         "sponsors",
         "cosponsors"
     ];

--- a/app/Bill.php
+++ b/app/Bill.php
@@ -72,8 +72,6 @@ class Bill extends Model
      * hide some relations from serialization
      */
     protected $hidden = [
-        "authors",
-        "coauthors",
         "sponsors",
         "cosponsors"
     ];

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -52,7 +52,7 @@ class DashboardController extends Controller
         if(!$bill) {
             abort(404);
         }
-        $bill->makeVisible(['sponsors', 'cosponsors']);
+        $bill->makeVisible(['authors', 'coauthors', 'sponsors', 'cosponsors']);
         $bill = $bill->toArray();
 
         if(Auth::check()) {

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -52,7 +52,7 @@ class DashboardController extends Controller
         if(!$bill) {
             abort(404);
         }
-        $bill->makeVisible(['authors', 'coauthors', 'sponsors', 'cosponsors']);
+        $bill->makeVisible(['sponsors', 'cosponsors']);
         $bill = $bill->toArray();
 
         if(Auth::check()) {

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -48,7 +48,7 @@ class DashboardController extends Controller
 
     public function singleBill($name) {
         $session = Session::current();
-        $bill = $session->bills->where('Name', '=', $name)->first();
+        $bill = Bill::where('Name', $name)->where('SessionId', $session->id)->first();
         if(!$bill) {
             abort(404);
         }

--- a/app/Http/Controllers/LegislatorApiController.php
+++ b/app/Http/Controllers/LegislatorApiController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Legislator;
+use App\Utils;
+use Illuminate\Http\Request;
+
+class LegislatorApiController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        return Utils::cache('legislators', function() {
+            return Legislator::all();
+        }, $request);
+    }
+}

--- a/app/Utils.php
+++ b/app/Utils.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App;
+
+use Illuminate\Support\Facades\Cache;
+
+class Utils {
+    /**
+     * Cache
+     *
+     * @param Illuminate\Http\Request $request an HTTP request object
+     * @param string $key cache and etag key
+     * @param function $getFn a function that returns the payload to cache (will be json_encoded)
+     * @return Illuminate\Http\Response
+     */
+    static function cache($key, $getFn, $request=null) {
+        $key = strtolower($key);
+        $etagKey = "{$key}__etag";
+        if(Cache::has($key) && Cache::has($etagKey)) {
+            $collection = json_decode(Cache::get($key));
+            $etag = Cache::get($etagKey);
+        } else {
+            if(method_exists($request, 'method') && $request->method() == 'HEAD') {
+                $collection = [];
+                $etag = 'expired';
+            } else {
+                $collection = $getFn();
+                $collectionJson = json_encode($collection);
+                $etag = md5($collectionJson);
+                Cache::forever($key, $collectionJson);
+                Cache::forever($etagKey, $etag);
+            }
+        }
+    
+        return response()->json([
+            $key => $collection
+        ])->setEtag($etag);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3841,9 +3841,9 @@
             }
         },
         "connect-history-api-fallback": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-            "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+            "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
         },
         "console-browserify": {
             "version": "1.1.0",
@@ -3880,7 +3880,7 @@
         },
         "content-disposition": {
             "version": "0.5.2",
-            "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
             "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
         },
         "content-type": {
@@ -5238,7 +5238,7 @@
             "dependencies": {
                 "array-flatten": {
                     "version": "1.1.1",
-                    "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+                    "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
                     "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
                 },
                 "safe-buffer": {
@@ -5702,7 +5702,7 @@
         },
         "finalhandler": {
             "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
             "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
             "requires": {
                 "debug": "2.6.9",
@@ -6973,9 +6973,9 @@
             }
         },
         "handle-thing": {
-            "version": "1.2.5",
-            "resolved": "http://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
-            "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
+            "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
         },
         "har-schema": {
             "version": "2.0.0",
@@ -7238,7 +7238,7 @@
         },
         "http-errors": {
             "version": "1.6.3",
-            "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "requires": {
                 "depd": "~1.1.2",
@@ -7264,7 +7264,7 @@
         },
         "http-proxy-middleware": {
             "version": "0.18.0",
-            "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
             "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
             "requires": {
                 "http-proxy": "^1.16.2",
@@ -7347,7 +7347,7 @@
                         },
                         "is-accessor-descriptor": {
                             "version": "0.1.6",
-                            "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "requires": {
                                 "kind-of": "^3.0.2"
@@ -7365,7 +7365,7 @@
                         },
                         "is-data-descriptor": {
                             "version": "0.1.4",
-                            "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "requires": {
                                 "kind-of": "^3.0.2"
@@ -9154,7 +9154,7 @@
         },
         "media-typer": {
             "version": "0.3.0",
-            "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
         },
         "mem": {
@@ -13989,71 +13989,69 @@
             "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
         },
         "spdy": {
-            "version": "3.4.7",
-            "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
-            "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.0.tgz",
+            "integrity": "sha512-ot0oEGT/PGUpzf/6uk4AWLqkq+irlqHXkrdbk51oWONh3bxQmBuljxPNl66zlRRcIJStWq0QkLUCPOPjgjvU0Q==",
             "requires": {
-                "debug": "^2.6.8",
-                "handle-thing": "^1.2.5",
+                "debug": "^4.1.0",
+                "handle-thing": "^2.0.0",
                 "http-deceiver": "^1.2.7",
-                "safe-buffer": "^5.0.1",
                 "select-hose": "^2.0.0",
-                "spdy-transport": "^2.0.18"
+                "spdy-transport": "^3.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
             }
         },
         "spdy-transport": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.1.tgz",
-            "integrity": "sha512-q7D8c148escoB3Z7ySCASadkegMmUZW8Wb/Q1u0/XBgDKMO880rLQDj8Twiew/tYi7ghemKUi/whSYOwE17f5Q==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+            "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
             "requires": {
-                "debug": "^2.6.8",
-                "detect-node": "^2.0.3",
+                "debug": "^4.1.0",
+                "detect-node": "^2.0.4",
                 "hpack.js": "^2.1.6",
-                "obuf": "^1.1.1",
-                "readable-stream": "^2.2.9",
-                "safe-buffer": "^5.0.1",
-                "wbuf": "^1.7.2"
+                "obuf": "^1.1.2",
+                "readable-stream": "^3.0.6",
+                "wbuf": "^1.7.3"
             },
             "dependencies": {
-                "process-nextick-args": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-                },
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    },
-                    "dependencies": {
-                        "safe-buffer": {
-                            "version": "5.1.2",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-                        }
+                        "ms": "^2.1.1"
                     }
                 },
+                "readable-stream": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+                    "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                },
                 "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+                    "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
                     "requires": {
                         "safe-buffer": "~5.1.0"
-                    },
-                    "dependencies": {
-                        "safe-buffer": {
-                            "version": "5.1.2",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-                        }
                     }
                 }
             }
@@ -15265,9 +15263,9 @@
             "integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg=="
         },
         "vuex": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/vuex/-/vuex-2.5.0.tgz",
-            "integrity": "sha512-5oJPOJySBgSgSzoeO+gZB/BbN/XsapgIF6tz34UwJqnGZMQurzIO3B4KIBf862gfc9ya+oduY5sSkq+5/oOilQ=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.0.1.tgz",
+            "integrity": "sha512-wLoqz0B7DSZtgbWL1ShIBBCjv22GV5U+vcBFox658g6V0s4wZV9P4YjCNyoHSyIBpj1f29JBoNQIqD82cR4O3w=="
         },
         "watchpack": {
             "version": "1.6.0",
@@ -15670,9 +15668,9 @@
             }
         },
         "webpack-dev-server": {
-            "version": "3.1.10",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.10.tgz",
-            "integrity": "sha512-RqOAVjfqZJtQcB0LmrzJ5y4Jp78lv9CK0MZ1YJDTaTmedMZ9PU9FLMQNrMCfVu8hHzaVLVOJKBlGEHMN10z+ww==",
+            "version": "3.1.14",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz",
+            "integrity": "sha512-mGXDgz5SlTxcF3hUpfC8hrQ11yhAttuUQWf1Wmb+6zo3x6rb7b9mIfuQvAPLdfDRCGRGvakBWHdHOa0I9p/EVQ==",
             "requires": {
                 "ansi-html": "0.0.7",
                 "bonjour": "^3.5.0",
@@ -15693,28 +15691,19 @@
                 "portfinder": "^1.0.9",
                 "schema-utils": "^1.0.0",
                 "selfsigned": "^1.9.1",
+                "semver": "^5.6.0",
                 "serve-index": "^1.7.2",
                 "sockjs": "0.3.19",
                 "sockjs-client": "1.3.0",
-                "spdy": "^3.4.1",
+                "spdy": "^4.0.0",
                 "strip-ansi": "^3.0.0",
                 "supports-color": "^5.1.0",
+                "url": "^0.11.0",
                 "webpack-dev-middleware": "3.4.0",
                 "webpack-log": "^2.0.0",
                 "yargs": "12.0.2"
             },
             "dependencies": {
-                "ajv": {
-                    "version": "6.6.2",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
-                    "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
-                    "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
                 "ansi-regex": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -15743,6 +15732,18 @@
                                 "ansi-regex": "^3.0.0"
                             }
                         }
+                    }
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "debug": {
@@ -15774,6 +15775,20 @@
                         "rimraf": "^2.2.8"
                     }
                 },
+                "execa": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+                    "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
                 "find-up": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -15782,9 +15797,17 @@
                         "locate-path": "^3.0.0"
                     }
                 },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
                 "globby": {
                     "version": "6.1.0",
-                    "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
                     "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
                     "requires": {
                         "array-union": "^1.0.1",
@@ -15796,7 +15819,7 @@
                     "dependencies": {
                         "pify": {
                             "version": "2.3.0",
-                            "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                             "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                         }
                     }
@@ -15834,19 +15857,19 @@
                     }
                 },
                 "os-locale": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
-                    "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+                    "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
                     "requires": {
-                        "execa": "^0.10.0",
+                        "execa": "^1.0.0",
                         "lcid": "^2.0.0",
                         "mem": "^4.0.0"
                     }
                 },
                 "p-limit": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-                    "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+                    "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
                     "requires": {
                         "p-try": "^2.0.0"
                     }
@@ -15883,6 +15906,11 @@
                         "ajv-errors": "^1.0.0",
                         "ajv-keywords": "^3.1.0"
                     }
+                },
+                "semver": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+                    "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
                 },
                 "string-width": {
                     "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "vue": "^2.5.21",
     "vue-resource": "^1.5.1",
     "vue-template-compiler": "^2.5.21",
-    "vuex": "^2.5.0"
+    "vuex": "^3.0.1"
   }
 }

--- a/resources/assets/js/components/all-bills.vue
+++ b/resources/assets/js/components/all-bills.vue
@@ -46,6 +46,7 @@
     const moment = require('moment')
     const pageSize = 50
     const billLoader = require('../bill-loader.js');
+    const legislatorLoader = require('../legislator-loader.js');
     const mapGetters = require('vuex').mapGetters
     const {getQueryVariable, updateQueryVariable, filterBills} = require('../utilities')
 
@@ -98,7 +99,7 @@
             getFilteredBills() {
                 if(this.q.length > 0) {
                     this.isFilterApplied = true
-                    return filterBills(this.bills, this.q)
+                    return filterBills(this.bills, this.legislators, this.q)
                 } else {
                     this.isFilterApplied = false
                     return this.bills
@@ -139,7 +140,7 @@
                 }
             }
         },
-        mixins: [billLoader],
+        mixins: [billLoader, legislatorLoader],
         mounted() {
             window.onpopstate = (history) => {
                 if(history.state && history.state.page) {

--- a/resources/assets/js/components/all-bills.vue
+++ b/resources/assets/js/components/all-bills.vue
@@ -9,7 +9,7 @@
             <div v-else-if="bills.length">
                 <div class="filters">
                     <form class="filters__search search" @submit.prevent="filterBillHandler">
-                        <input class="search__input" type="search" autocomplete="off" v-model="q" placeholder="Search by bill number, keyword, committee, subject...">
+                        <input class="search__input" type="search" autocomplete="off" v-model="q" placeholder="Search by bill number, keyword, author, committee, subject...">
                         <input class="search__submit button" type="submit" value="Search">
                     </form>
 

--- a/resources/assets/js/components/bill.vue
+++ b/resources/assets/js/components/bill.vue
@@ -107,10 +107,22 @@
                 return this.user.tracked_bills.map(b=>parseInt(b.BillId)).includes(this.bill.Id);
             },
             authors() {
-                return this.legislators.filter(l => this.b.authorIds.includes(l.Id))
+                return this
+                    .legislators
+                    .filter(l => this
+                        .b.authorIds
+                        .map(id => parseInt(id))
+                        .includes(parseInt(l.Id))
+                    )
             },
             coauthors() {
-                return this.legislators.filter(l => this.b.coauthorIds.includes(l.Id))
+                return this
+                    .legislators
+                    .filter(l => this
+                        .b.coauthorIds
+                        .map(id => parseInt(id))
+                        .includes(parseInt(l.Id))
+                    )
             },
             ...mapGetters(["legislators"])
         },

--- a/resources/assets/js/components/bill.vue
+++ b/resources/assets/js/components/bill.vue
@@ -56,7 +56,7 @@
                             </div>
                             <div class="info__body">
                                 <span v-for="(committee, index) in bill.committees">
-                                    ({{committee.Chamber.substr(0,1)}}) {{committee.Name}}<span v-if="index!=bill.committees.length-1">,&nbsp;</span>
+                                    ({{committee.Chamber.substr(0,1)}}) {{committee.Name}}<span v-if="index!=bill.committees.length-1"><br/></span>
                                 </span>
                             </div>
                         </div>
@@ -66,7 +66,7 @@
                             </div>
                             <div class="info__body">
                                 <span v-for="(subject, index) in bill.subjects">
-                                    {{subject.Name}}<span v-if="index!=bill.subjects.length-1">,&nbsp;</span>
+                                    {{subject.Name}}<span v-if="index!=bill.subjects.length-1"><br/></span>
                                 </span>
                             </div>
                         </div>

--- a/resources/assets/js/components/bill.vue
+++ b/resources/assets/js/components/bill.vue
@@ -30,27 +30,27 @@
                         You are tracking this legislation
                     </div>
                     <div class="bill__meta">
-                        <div class="info" v-if="Array.isArray(bill.authors) && bill.authors.length">
+                        <div class="info" v-if="Array.isArray(authors) && authors.length">
                             <div class="info__label">
-                                {{bill.authors.length | pluralizeAuthors}}
+                                {{authors.length | pluralizeAuthors}}
                             </div>
                             <div class="info__body">
-                                <span v-for="(author, index) in bill.authors">
-                                    ({{author.Chamber.substr(0,1)}}) {{author.LastName}}<span v-if="index!=bill.authors.length-1"><br/></span>
+                                <span v-for="(author, index) in authors">
+                                    ({{author.Chamber.substr(0,1)}}) {{author.LastName}}<span v-if="index!=authors.length-1"><br/></span>
                                 </span>
                             </div>
                         </div>
-                        <div class="info" v-if="Array.isArray(bill.coauthors) && bill.coauthors.length">
+                        <div class="info" v-if="Array.isArray(coauthors) && coauthors.length">
                             <div class="info__label">
-                                {{bill.coauthors.length | pluralizeCoauthors}}
+                                {{coauthors.length | pluralizeCoauthors}}
                             </div>
                             <div class="info__body">
                                 <!-- show the first three coauthors -->
-                                <span v-for="(author, index) in bill.coauthors" v-if="index < 3">
-                                    ({{author.Chamber.substr(0,1)}}) {{author.LastName}}<span v-if="index!=bill.coauthors.length-1"><br/></span>
+                                <span v-for="(author, index) in coauthors" v-if="index < 3">
+                                    ({{author.Chamber.substr(0,1)}}) {{author.LastName}}<span v-if="index!=coauthors.length-1"><br/></span>
                                 </span>
                                 <!-- follow with '...' if there are more than three coauthors -->
-                                <span v-if="bill.coauthors.length > 3">...</span> 
+                                <span v-if="coauthors.length > 3">...</span> 
                             </div>
                         </div>
                         <div class="info" v-if="bill.committees.length">
@@ -96,6 +96,8 @@
 </template>
 
 <script>
+    const mapGetters = require('vuex').mapGetters
+
     module.exports = {
         computed: {
             user() {
@@ -103,7 +105,14 @@
             },
             isTracked() {
                 return this.user.tracked_bills.map(b=>parseInt(b.BillId)).includes(this.bill.Id);
-            }
+            },
+            authors() {
+                return this.legislators.filter(l => this.b.authorIds.includes(l.Id))
+            },
+            coauthors() {
+                return this.legislators.filter(l => this.b.coauthorIds.includes(l.Id))
+            },
+            ...mapGetters(["legislators"])
         },
         filters: {
             truncate(theStringToTruncate) {

--- a/resources/assets/js/components/bill.vue
+++ b/resources/assets/js/components/bill.vue
@@ -45,9 +45,12 @@
                                 {{bill.coauthors.length | pluralizeCoauthors}}
                             </div>
                             <div class="info__body">
-                                <span v-for="(author, index) in bill.coauthors">
+                                <!-- show the first three coauthors -->
+                                <span v-for="(author, index) in bill.coauthors" v-if="index < 3">
                                     ({{author.Chamber.substr(0,1)}}) {{author.LastName}}<span v-if="index!=bill.coauthors.length-1"><br/></span>
                                 </span>
+                                <!-- follow with '...' if there are more than three coauthors -->
+                                <span v-if="bill.coauthors.length > 3">...</span> 
                             </div>
                         </div>
                         <div class="info" v-if="bill.committees.length">

--- a/resources/assets/js/components/bill.vue
+++ b/resources/assets/js/components/bill.vue
@@ -30,7 +30,7 @@
                         You are tracking this legislation
                     </div>
                     <div class="bill__meta">
-                        <div class="info" v-if="bill.authors.length">
+                        <div class="info" v-if="Array.isArray(bill.authors) && bill.authors.length">
                             <div class="info__label">
                                 {{bill.authors.length | pluralizeAuthors}}
                             </div>
@@ -40,7 +40,7 @@
                                 </span>
                             </div>
                         </div>
-                        <div class="info" v-if="bill.coauthors.length">
+                        <div class="info" v-if="Array.isArray(bill.coauthors) && bill.coauthors.length">
                             <div class="info__label">
                                 {{bill.coauthors.length | pluralizeCoauthors}}
                             </div>

--- a/resources/assets/js/components/bill.vue
+++ b/resources/assets/js/components/bill.vue
@@ -30,6 +30,26 @@
                         You are tracking this legislation
                     </div>
                     <div class="bill__meta">
+                        <div class="info" v-if="bill.authors.length">
+                            <div class="info__label">
+                                {{bill.authors.length | pluralizeAuthors}}
+                            </div>
+                            <div class="info__body">
+                                <span v-for="(author, index) in bill.authors">
+                                    ({{author.Chamber.substr(0,1)}}) {{author.LastName}}<span v-if="index!=bill.authors.length-1"><br/></span>
+                                </span>
+                            </div>
+                        </div>
+                        <div class="info" v-if="bill.coauthors.length">
+                            <div class="info__label">
+                                {{bill.coauthors.length | pluralizeCoauthors}}
+                            </div>
+                            <div class="info__body">
+                                <span v-for="(author, index) in bill.coauthors">
+                                    ({{author.Chamber.substr(0,1)}}) {{author.LastName}}<span v-if="index!=bill.coauthors.length-1"><br/></span>
+                                </span>
+                            </div>
+                        </div>
                         <div class="info" v-if="bill.committees.length">
                             <div class="info__label">
                                 {{bill.committees.length | pluralizeCommittees}}
@@ -94,6 +114,12 @@
             },
             pluralizeSubjects(value) {
                 return value == 1 ? "Subject" : "Subjects";
+            },
+            pluralizeAuthors(value) {
+                return value == 1 ? "Author" : "Authors";
+            },
+            pluralizeCoauthors(value) {
+                return value == 1 ? "Coauthor" : "Coauthors";
             }
         },
         data() {

--- a/resources/assets/js/components/my-bills.vue
+++ b/resources/assets/js/components/my-bills.vue
@@ -39,7 +39,8 @@
 
 <script>
     const moment = require('moment');
-    const billLoader = require('../bill-loader.js')
+    const billLoader = require('../bill-loader')
+    const legislatorLoader = require('../legislator-loader')
     const mapGetters = require("vuex").mapGetters
     const mapActions = require("vuex").mapActions
     const { filterBills } = require('../utilities')
@@ -53,13 +54,13 @@
             filteredBills() {
                 if(this.q.length > 0) {
                     this.isFilterApplied = true
-                    return filterBills(this.bills, this.q)
+                    return filterBills(this.myBills, this.legislators, this.q)
                 } else {
                     this.isFilterApplied = false
                     return this.myBills
                 }
             },
-            ...mapGetters(["myBills"])
+            ...mapGetters(["myBills", "legislators"])
         },
         data() {
             return {
@@ -89,11 +90,7 @@
                     this.appendBills(res.body.bills)
                 })
             },
-            getFilteredBills() {
-
-            },
             filterBillHandler() {
-
                 if(this.currentPage > this.nPages-1) {
                     this.currentPage = this.nPages-1
                 }
@@ -105,6 +102,6 @@
             },
             ...mapActions(['appendBills'])
         },
-        mixins: [billLoader]
+        mixins: [billLoader, legislatorLoader]
     }
 </script>

--- a/resources/assets/js/legislator-loader.js
+++ b/resources/assets/js/legislator-loader.js
@@ -1,0 +1,62 @@
+const mapActions = require("vuex").mapActions;
+const mapGetters = require("vuex").mapGetters
+
+module.exports = {
+    computed: {
+        ...mapGetters(['legislators'])
+    },
+    methods: {
+        loadLegislatorsFromServer(callback) {
+            this.$http.get("/api/legislators").then(res => {
+                this.storeLegislators(res.body.legislators)
+
+                if(typeof callback === "function") {
+                    callback()
+                }
+
+                if(window.localStorage) {
+                    localStorage.setItem("legislators__etag", res.headers.map.etag[0])
+                    localStorage.setItem("legislators", JSON.stringify(res.body.legislators))
+                }
+            }, res => {
+                console.log(res)
+            })            
+        },
+        loadLegislatorsFromLocalStorage(callback) {
+            if(window.localStorage) {
+                let legislators = localStorage.getItem("legislators")
+                let etag = localStorage.getItem("legislators__etag")
+                if(!legislators || !etag) {
+                    this.loadLegislatorsFromServer(callback);
+                } else {
+                    legislators = JSON.parse(legislators)
+                    this.storeLegislators(legislators)
+                    this.isLoading = false
+                    if(typeof callback === "function") {
+                        callback()
+                    }
+                    this.$http.head("/api/legislators").then(res => {
+                        if(!res.headers.map.etag || res.headers.map.etag[0] != etag) {
+                            this.loadLegislatorsFromServer(callback)
+                        }
+                    })
+                }
+            }
+        },
+        loadLegislators(callback) {
+            if(window.localStorage) {
+                this.loadLegislatorsFromLocalStorage(callback);
+            } else {
+                this.loadLegislatorsFromServer(callback);
+            }
+        },
+        ...mapActions(["storeLegislators"])
+    },
+    mounted() {
+        this.loadLegislators(() => {
+            if(typeof this.legislatorsLoadedHandler === "function") {
+                this.legislatorsLoadedHandler()
+            }
+        })
+    }
+};

--- a/resources/assets/js/store.js
+++ b/resources/assets/js/store.js
@@ -7,7 +7,8 @@ const state = {
     user: {
         tracked_bills: []
     },
-    bills: []
+    bills: [],
+    legislators: []
 }
 
 const getters = {
@@ -22,7 +23,8 @@ const getters = {
         } else {
             return []
         }
-    }
+    },
+    legislators: state => state.global.legislators
 }
 
 const actions = {
@@ -44,6 +46,10 @@ const actions = {
     },
     applyBillSort({commit}, {sortCol, sortAsc}) {
         commit('applyBillSort', {sortCol, sortAsc})
+    },
+
+    storeLegislators({commit}, legislators) {
+        commit('storeLegislators', legislators)
     }
 }
 
@@ -120,7 +126,11 @@ const mutations = {
                 ? aValue < bValue ? -1 : (aValue > bValue ? 1 : 0)
                 : aValue > bValue ? -1 : (aValue < bValue ? 1 : 0)
         })
-    }
+    },
+    // legislator mutations
+    ['storeLegislators'] (state, legislators) {
+        state.legislators = legislators
+    },
 }
 
 Vue.use(Vuex)

--- a/resources/assets/js/utilities.js
+++ b/resources/assets/js/utilities.js
@@ -70,8 +70,10 @@ const filterBills = (bills, legislators, query) => {
     const matchesCommittees = (b) => b.committees.some(e=>contains(e.Name,q));
     const matchesTitle = (b) => contains(b.Title,q);
     const matchesDescription = (b) => contains(b.Description,q);
-    const matchesAuthor = b => b.authorIds && legislators.filter(l => b.authorIds.includes(l.Id)).some(l => authoredBy(l,q));
-    const matchesCoauthor = b => b.coauthorIds && legislators.filter(l => b.coauthorIds.includes(l.Id)).some(l => authoredBy(l, q));
+    const isAuthorOnBill = b => l => b.authorIds.map(id => parseInt(id)).includes(parseInt(l.Id))
+    const matchesAuthor = b => b.authorIds && legislators.filter(isAuthorOnBill(b)).some(l => authoredBy(l,q));
+    const isCoauthorOnBill = b => l => b.coauthorIds.map(id => parseInt(id)).includes(parseInt(l.Id))
+    const matchesCoauthor = b => b.coauthorIds && legislators.filter(isCoauthorOnBill(b)).some(l => authoredBy(l, q));
     return bills.filter(b =>
         matchesName(b)
         || matchesSubjects(b)

--- a/resources/assets/js/utilities.js
+++ b/resources/assets/js/utilities.js
@@ -70,8 +70,8 @@ const filterBills = (bills, query) => {
     const matchesCommittees = (b) => b.committees.some(e=>contains(e.Name,q));
     const matchesTitle = (b) => contains(b.Title,q);
     const matchesDescription = (b) => contains(b.Description,q);
-    const matchesAuthor = b => b.authors.some(l => authoredBy(l,q));
-    const matchesCoauthor = b => b.coauthors.some(l => authoredBy(l,q));
+    const matchesAuthor = b => b.authors && b.authors.some(l => authoredBy(l,q));
+    const matchesCoauthor = b => b.coauthors && b.coauthors.some(l => authoredBy(l, q));
     return bills.filter(b =>
         matchesName(b)
         || matchesSubjects(b)

--- a/resources/assets/js/utilities.js
+++ b/resources/assets/js/utilities.js
@@ -59,7 +59,7 @@ const authoredBy = (legislator, q) => {
 }
 
 /// filter bills to those matching the search string.
-const filterBills = (bills, query) => {
+const filterBills = (bills, legislators, query) => {
     const q = query.toLowerCase();
     // find parts of the query string matching a bill name ("sb 123", "hb1004") or number ("123", "1004")
     const l = q.match(/([hs][bcjr]\s*)?(\d*)/g).map(s=>removeSpaces(s));
@@ -70,8 +70,8 @@ const filterBills = (bills, query) => {
     const matchesCommittees = (b) => b.committees.some(e=>contains(e.Name,q));
     const matchesTitle = (b) => contains(b.Title,q);
     const matchesDescription = (b) => contains(b.Description,q);
-    const matchesAuthor = b => b.authors && b.authors.some(l => authoredBy(l,q));
-    const matchesCoauthor = b => b.coauthors && b.coauthors.some(l => authoredBy(l, q));
+    const matchesAuthor = b => b.authorIds && legislators.filter(l => b.authorIds.includes(l.Id)).some(l => authoredBy(l,q));
+    const matchesCoauthor = b => b.coauthorIds && legislators.filter(l => b.coauthorIds.includes(l.Id)).some(l => authoredBy(l, q));
     return bills.filter(b =>
         matchesName(b)
         || matchesSubjects(b)

--- a/resources/assets/js/utilities.js
+++ b/resources/assets/js/utilities.js
@@ -53,6 +53,10 @@ const containsBillName = (name, qNames, qNumbers) => {
     return  qNames.some(q => q === bName) 
         || qNumbers.some(q => q === bNum);
 };
+const authoredBy = (legislator, q) => {
+    return contains(legislator.FirstName, q) 
+        || contains(legislator.LastName, q);
+}
 
 /// filter bills to those matching the search string.
 const filterBills = (bills, query) => {
@@ -66,12 +70,16 @@ const filterBills = (bills, query) => {
     const matchesCommittees = (b) => b.committees.some(e=>contains(e.Name,q));
     const matchesTitle = (b) => contains(b.Title,q);
     const matchesDescription = (b) => contains(b.Description,q);
+    const matchesAuthor = b => b.authors.some(l => authoredBy(l,q));
+    const matchesCoauthor = b => b.coauthors.some(l => authoredBy(l,q));
     return bills.filter(b =>
         matchesName(b)
         || matchesSubjects(b)
         || matchesCommittees(b)
         || matchesTitle(b)
-        || matchesDescription(b));
+        || matchesDescription(b)
+        || matchesAuthor(b)
+        || matchesCoauthor(b));
 }
 
 export {

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,3 +24,4 @@ Route::post('/track', 'TrackingApiController@track');
 Route::post('/stop-tracking', 'TrackingApiController@stopTracking');
 Route::post('/bills/{id}/toggle-email-subscription/', 'TrackingApiController@toggleEmailSubscription');
 Route::post('/bills/{id}/toggle-sms-subscription/', 'TrackingApiController@toggleSmsSubscription');
+Route::get('/legislators', 'LegislatorApiController@index');


### PR DESCRIPTION
* Adds support for searching by author/coauthor on the `All Legislation` page.
* Adds the authors and an abbreviated list of coauthors to the search results. This starts to duplicate a lot of the functionality of the 'single bill' view, but I thought it was important that the search result would show the name of the person in the search query.
* Delimits the `All Legislation` committees, subjects, authors, and coauthors with line breaks instead of commas. I think this lays out a bit neater but I'm not married to it.
  
Resolves #88 