### PR TITLE
Fix error for returning users in a new session.

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -64,7 +64,7 @@ class User extends Authenticatable
     public function trackedBills() {
         $session = Session::current();
         return $this->hasMany(UserBill::class, 'UserId', 'id')
-            ->join(Bill::class, 'UserBill.BillId', '=', 'Bill.Id')
+            ->join('Bill', 'UserBill.BillId', '=', 'Bill.Id')
             ->where('SessionId', '=', $session->Id)
             ->select('UserBill.*');
     }

--- a/app/User.php
+++ b/app/User.php
@@ -54,7 +54,7 @@ class User extends Authenticatable
         return $this->belongsToMany(Bill::class, 'UserBill', 'UserId', 'BillId')
             ->with(["actions", "scheduledActions",])
             ->withPivot('ReceiveAlertEmail', 'ReceiveAlertSms')
-            ->where('Link', 'like', "/$session->Name%")
+            ->where('SessionId', '=', $session->Id)
             ->orderBy('Name');
     }
 
@@ -65,7 +65,7 @@ class User extends Authenticatable
         $session = Session::current();
         return $this->hasMany(UserBill::class, 'UserId', 'id')
             ->join(Bill::class, 'UserBill.BillId', '=', 'Bill.Id')
-            ->where('Link', 'like', "/$session->Name%")
+            ->where('SessionId', '=', $session->Id)
             ->select('UserBill.*');
     }
 

--- a/app/User.php
+++ b/app/User.php
@@ -50,14 +50,23 @@ class User extends Authenticatable
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function bills() {
+        $session = Session::current();
         return $this->belongsToMany(Bill::class, 'UserBill', 'UserId', 'BillId')
             ->with(["actions", "scheduledActions",])
             ->withPivot('ReceiveAlertEmail', 'ReceiveAlertSms')
+            ->where('Link', 'like', "/$session->Name%")
             ->orderBy('Name');
     }
 
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
     public function trackedBills() {
-        return $this->hasMany(UserBill::class, 'UserId', 'id');
+        $session = Session::current();
+        return $this->hasMany(UserBill::class, 'UserId', 'id')
+            ->join(Bill::class, 'UserBill.BillId', '=', 'Bill.Id')
+            ->where('Link', 'like', "/$session->Name%")
+            ->select('UserBill.*');
     }
 
     public function track($param, $startTracking=true) {

--- a/resources/assets/sass/_home.scss
+++ b/resources/assets/sass/_home.scss
@@ -1,5 +1,5 @@
 .welcome {
-    max-width: 600px;
+    max-width: 900px;
 
     li {
         margin-bottom: $xs;

--- a/resources/views/all-bills.blade.php
+++ b/resources/views/all-bills.blade.php
@@ -9,8 +9,8 @@
             <p><strong>Ping the People</strong> makes it easy to discover, track, and get instant updates on Indiana legislation that matters to you. Here's how to get started:</p>
             <ol>
                 <li>Search <a href="/account">all legislation</a> below by bill number, committee, subject, or keyword.</li>
-                <li>Add legislation to your watch list by clicking the <em>Tracking</em> toggle (<img class="welcome__tracking-icon" src="images/toggle.svg" alt="use the track legislation checkbox">).</li>
-                <li>Check <a href="/">my watch list</a> for the latest legislative updates and scheduled events. You can also choose to receive email and/or text message updates for each item.</li>
+                <li>Add legislation to your watchlist by clicking the <em>Tracking</em> toggle (<img class="welcome__tracking-icon" src="images/toggle.svg" alt="use the track legislation checkbox">).</li>
+                <li>Check <a href="/">my watchlist</a> for the latest legislative updates and scheduled events. You can also choose to receive email and/or text message updates for each item.</li>
                 <li>Confirm your email and mobile <a href="/account">settings</a> for instant updates and daily roundups.</li>
             </ol>
         </div>

--- a/resources/views/all-bills.blade.php
+++ b/resources/views/all-bills.blade.php
@@ -8,10 +8,10 @@
         <div class="welcome">
             <p><strong>Ping the People</strong> makes it easy to discover, track, and get instant updates on Indiana legislation that matters to you. Here's how to get started:</p>
             <ol>
-                <li>Search legislation by bill number, committee, subject, or keyword.</li>
-                <li>Toggle tracking (<img class="welcome__tracking-icon" src="images/toggle.svg" alt="use the track legislation checkbox">) to add legislation to your watchlist.</li>
-                <li>Check <watchlist-link><strong>My watch list</strong></watchlist-link> for the latest legislative updates and scheduled events. You can also choose to receive email or text message updates for each item.</li>
-                <li>Confirm your email and mobile <a href="/account">contact preferences</a> for instant updates and daily roundups.</li>
+                <li>Search <a href="/account">all legislation</a> below by bill number, committee, subject, or keyword.</li>
+                <li>Add legislation to your watch list by clicking the <em>Tracking</em> toggle (<img class="welcome__tracking-icon" src="images/toggle.svg" alt="use the track legislation checkbox">).</li>
+                <li>Check <a href="/">my watch list</a> for the latest legislative updates and scheduled events. You can also choose to receive email and/or text message updates for each item.</li>
+                <li>Confirm your email and mobile <a href="/account">settings</a> for instant updates and daily roundups.</li>
             </ol>
         </div>
         <hr>

--- a/resources/views/all-bills.blade.php
+++ b/resources/views/all-bills.blade.php
@@ -6,12 +6,12 @@
     @if($showWelcome)
         <h1>Welcome to <strong>Ping the People</strong>!</h1>
         <div class="welcome">
-            <p>You're not yet tracking any legislation. <strong>Ping the People</strong> makes it easy to discover, track, and get instant updates on Indiana legislation that is important to you. Here's how to get started:</p>
+            <p><strong>Ping the People</strong> makes it easy to discover, track, and get instant updates on Indiana legislation that matters to you. Here's how to get started:</p>
             <ol>
-                <li>Search legislation by number, committee, subject, or keyword.</li>
+                <li>Search legislation by bill number, committee, subject, or keyword.</li>
                 <li>Toggle tracking (<img class="welcome__tracking-icon" src="images/toggle.svg" alt="use the track legislation checkbox">) to add legislation to your watchlist.</li>
                 <li>Check <watchlist-link><strong>My watch list</strong></watchlist-link> for the latest legislative updates and scheduled events. You can also choose to receive email or text message updates for each item.</li>
-                <li>Confirm your email and mobile <a href="/account">contact preferences</a> for updates and daily roundups.</li>
+                <li>Confirm your email and mobile <a href="/account">contact preferences</a> for instant updates and daily roundups.</li>
             </ol>
         </div>
         <hr>

--- a/resources/views/my-watch-list.blade.php
+++ b/resources/views/my-watch-list.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.main')
 
-@section('title', 'My watch list | Ping the People')
+@section('title', 'My watchlist | Ping the People')
 
 @section('content')
     <div class="bill-list bill-list--tracked-by-user">

--- a/resources/views/shared/nav-list.blade.php
+++ b/resources/views/shared/nav-list.blade.php
@@ -1,6 +1,6 @@
 <ul class="nav-list">
     <li class="nav-item {{ (Request::is('/') ? 'is-active' : '') }}">
-        <a href="{{url('/')}}">My watch list</a>
+        <a href="{{url('/')}}">My watchlist</a>
     </li>
     <li class="nav-item {{ (Request::is('bills/*') || Request::is('bills') ? 'is-active' : '') }}">
         <a href="{{url('/bills')}}">All legislation</a>


### PR DESCRIPTION
When users with watchlists in previous sessions visit for the first time in a new session, the app attempts to load their old watchlist. This causes an error because those previously watched bills aren't present in the new session. This PR resolves the issue by filtering the bills tracked by the user to the current session.

This PR also makes a few editorial updates: I tweaked the welcome verbiage and replaced all uses of "watch list" with "watchlist." (I don't care which one we use, but we were using both.)